### PR TITLE
remove firewall announement and add license notice

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `3.1` (LTS/Current)
@@ -134,6 +128,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.aspnet.preview.md
+++ b/README.aspnet.preview.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `5.0` (Preview)
@@ -126,6 +120,8 @@ See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/micr
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Repos
 
 ## .NET Core 2.1/3.1
@@ -98,6 +92,8 @@ See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/micr
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.runtime-deps.md
+++ b/README.runtime-deps.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `3.1` (LTS/Current)
@@ -98,6 +92,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.runtime-deps.preview.md
+++ b/README.runtime-deps.preview.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `5.0` (Preview)
@@ -90,6 +84,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `3.1` (LTS/Current)
@@ -130,6 +124,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.runtime.preview.md
+++ b/README.runtime.preview.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `5.0` (Preview)
@@ -122,6 +116,8 @@ See [Microsoft Support for .NET](https://github.com/dotnet/core/blob/master/micr
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.samples.md
+++ b/README.samples.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `dotnetapp` [(*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
@@ -128,6 +122,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Discover licensing for Linux image contents](https://github.com/dotnet/dotnet-docker/blob/master/documentation/image-artifact-details.md)

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `3.1` (LTS/Current)
@@ -132,6 +126,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)

--- a/README.sdk.preview.md
+++ b/README.sdk.preview.md
@@ -1,9 +1,3 @@
-## Important: Client Firewall Rules Update to Microsoft Container Registry (MCR)
-
-To provide a consistent FQDNs, the data endpoint will be changing from *.cdn.mscr.io to *.data.mcr.microsoft.com
-
-For more info, see [MCR Client Firewall Rules](https://aka.ms/mcr/firewallrules).
-
 # Featured Tags
 
 * `5.0` (Preview)
@@ -125,6 +119,8 @@ See [Microsoft Support for .NET Core](https://github.com/dotnet/core/blob/master
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
 # License
+- Legal Notice: [Container License Information](https://aka.ms/mcr/osslegalnotice)
+
 
 * [.NET Core license](https://github.com/dotnet/dotnet-docker/blob/master/LICENSE)
 * [Windows Nano Server license](https://hub.docker.com/_/microsoft-windows-nanoserver/) (only applies to Windows containers)


### PR DESCRIPTION
We no longer want the firewall announcement and we want a standard license info link on all the docker hub readmes